### PR TITLE
Minimum required changes to support convention-based View resolution.

### DIFF
--- a/spring-soy-view/src/main/java/pl/matisoft/soy/SoyTemplateViewResolver.java
+++ b/spring-soy-view/src/main/java/pl/matisoft/soy/SoyTemplateViewResolver.java
@@ -56,6 +56,8 @@ public class SoyTemplateViewResolver extends AbstractTemplateViewResolver {
 
     private boolean ignoreHtmlView = false;
 
+    private String indexView = "index";
+
     public SoyTemplateViewResolver() {
         super();
         setExposeSpringMacroHelpers(false);
@@ -83,8 +85,8 @@ public class SoyTemplateViewResolver extends AbstractTemplateViewResolver {
         Preconditions.checkNotNull(viewName, "viewName cannot be null!");
         Preconditions.checkNotNull(templateRenderer, "templateRenderer cannot be null!");
 
-        final SoyView view = (SoyView) super.buildView(viewName);
-        view.setTemplateName(viewName);
+        final SoyView view = (SoyView) super.buildView(orIndexView(normalize(viewName)));
+        view.setTemplateName(view.getUrl());
         view.setContentType(contentType());
         view.setTemplateRenderer(templateRenderer);
         view.setModelAdjuster(modelAdjuster);
@@ -105,6 +107,35 @@ public class SoyTemplateViewResolver extends AbstractTemplateViewResolver {
         }
 
         return view;
+    }
+
+    /**
+     * Map / to a default view name.
+     * @param viewName The view name.
+     * @return The defaulted view name.
+     */
+    private String orIndexView(String viewName) {
+        return viewName == "" ? indexView : viewName;
+    }
+
+    /**
+     * Remove beginning and ending slashes, then replace all occurrences of / with .
+     *
+     * @param viewName The Spring viewName
+     * @return The name of the view, dot separated.
+     */
+    private String normalize(final String viewName) {
+        String normalized = viewName;
+
+        if (normalized.startsWith("/")) {
+            normalized = normalized.substring(0);
+        }
+
+        if (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+
+        return normalized.replaceAll("/", ".");
     }
 
     private String contentType() {
@@ -168,4 +199,7 @@ public class SoyTemplateViewResolver extends AbstractTemplateViewResolver {
         this.soyMsgBundleResolver = soyMsgBundleResolver;
     }
 
+    public void setIndexView(String indexView) {
+        this.indexView = indexView;
+    }
 }


### PR DESCRIPTION
The meat is on lines 98 and 99.  If we use the _url_ property of the built SoyView, we can utilize the _prefix_ property of _ViewResolver_.  As in:

``` xml
<bean id="soyViewResolver" class="pl.matisoft.soy.SoyTemplateViewResolver">
    <property name="prefix" value="app."/>
    <property name="debugOn" value="${app.debug}"/>
    <property name="templateFilesResolver" ref="soyTemplateFilesResolver"/>
    <property name="templateRenderer" ref="tofuRenderer"/>
    <property name="tofuCompiler" ref="tofuCompiler"/>
    <property name="globalModelResolver" ref="soyRunTimeGlobalModelResolver"/>
    <property name="localeProvider" ref="soyLocaleProvider"/>
    <property name="soyMsgBundleResolver" ref="soyMessageBundleResolver"/>
    <property name="encoding" value="UTF-8"/>
    <property name="order" value="0"/>
</bean>
```

A default viewName is provided to handle the case where a View is dispatched to /.
