### PR TITLE
switch major dependencies to provided scope.

### DIFF
--- a/spring-soy-view/pom.xml
+++ b/spring-soy-view/pom.xml
@@ -42,18 +42,21 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <version>3.2.3.RELEASE</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
             <version>3.2.3.RELEASE</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
             <version>2.5</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
For https://github.com/mati1979/spring-soy-view/issues/10.

Not sure if you were wanting to address some of the larger dependencies in the _soy_ dependency, notably icu4j and guava, since those are very common as well.
