### PR TITLE
- scope of spring and servlet-api dependencies changed to provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -19,6 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>4.11</junit.version>
         <mockito.version>1.9.5</mockito.version>
+        <spring.version>3.2.3.RELEASE</spring.version>
     </properties>
 
     <licenses>
@@ -92,6 +94,41 @@
             </plugin>
         </plugins>
     </build>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-web</artifactId>
+                <version>${spring.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-webmvc</artifactId>
+                <version>${spring.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>javax.servlet</groupId>
+                <artifactId>servlet-api</artifactId>
+                <version>2.5</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-all</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <modules>
         <module>spring-soy-view</module>

--- a/spring-soy-view-ajax-compiler/pom.xml
+++ b/spring-soy-view-ajax-compiler/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -79,22 +80,16 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>3.2.3.RELEASE</version>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
-            <version>3.2.3.RELEASE</version>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
@@ -114,15 +109,11 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/spring-soy-view-ajax-compiler/src/test/java/pl/matisoft/soy/ajax/SoyAjaxControllerTest.java
+++ b/spring-soy-view-ajax-compiler/src/test/java/pl/matisoft/soy/ajax/SoyAjaxControllerTest.java
@@ -35,16 +35,12 @@ public class SoyAjaxControllerTest {
 
     @InjectMocks
     private SoyAjaxController soyAjaxController = new SoyAjaxController();
-
     @Mock
     private TemplateFilesResolver templateFilesResolver;
-
     @Mock
     private SoyMsgBundleResolver soyMsgBundleResolver;
-
     @Mock
     private LocaleProvider localeProvider;
-
     @Mock
     private TofuCompiler tofuCompiler;
 
@@ -88,7 +84,7 @@ public class SoyAjaxControllerTest {
         when(tofuCompiler.compileToJsSrc(url2, null)).thenReturn(Optional.of(jsData2));
 
         final ResponseEntity<String> responseEntity = soyAjaxController.compile("", new String[]{templateName1, templateName2}, null, "true", request);
-        Assert.assertEquals("data should be equal", jsData2 + jsData1, responseEntity.getBody());
+        Assert.assertEquals("data should be equal", jsData1 + jsData2, responseEntity.getBody());
         Assert.assertTrue("http status should be equal", (responseEntity.getStatusCode() == HttpStatus.OK));
     }
 

--- a/spring-soy-view/pom.xml
+++ b/spring-soy-view/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -61,22 +62,16 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>3.2.3.RELEASE</version>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
-            <version>3.2.3.RELEASE</version>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
@@ -100,15 +95,11 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
- fixed unit test
- changed the dependencies of spring and servlet-api to scope provided
- introduced dependency management in root pom

Change-Id: I600920111c911c659f96a5b362718a15cfa4fbdc

With the change you don't have any problems running spring-soy-view with Servlet API 3 and Spring 4
