### PR TITLE
reworking DefaultTemplateFilesResolver to be more agnostic to location of templates

### DIFF
--- a/spring-soy-view/src/main/java/pl/matisoft/soy/config/SpringSoyViewBaseConfig.java
+++ b/spring-soy-view/src/main/java/pl/matisoft/soy/config/SpringSoyViewBaseConfig.java
@@ -90,7 +90,7 @@ public class SpringSoyViewBaseConfig {
         defaultTemplateFilesResolver.setHotReloadMode(hotReloadMode);
         defaultTemplateFilesResolver.setRecursive(recursive);
         defaultTemplateFilesResolver.setFilesExtension(fileExtension);
-        defaultTemplateFilesResolver.setTemplatesLocation(new ServletContextResource(servletContext, templatesPath));
+        defaultTemplateFilesResolver.setTemplatesLocation(templatesPath);
 
         return defaultTemplateFilesResolver;
     }

--- a/spring-soy-view/src/main/java/pl/matisoft/soy/holder/DefaultCompiledTemplatesHolder.java
+++ b/spring-soy-view/src/main/java/pl/matisoft/soy/holder/DefaultCompiledTemplatesHolder.java
@@ -16,8 +16,6 @@ import pl.matisoft.soy.config.SoyViewConfigDefaults;
 import pl.matisoft.soy.template.EmptyTemplateFilesResolver;
 import pl.matisoft.soy.template.TemplateFilesResolver;
 
-import javax.inject.Inject;
-
 /**
  * Created with IntelliJ IDEA.
  * User: mati
@@ -41,7 +39,7 @@ public class DefaultCompiledTemplatesHolder implements InitializingBean, Compile
     private boolean preCompileTemplates = SoyViewConfigDefaults.DEFAULT_PRECOMPILE_TEMPLATES;
 
     public Optional<SoyTofu> compiledTemplates() throws IOException {
-        if (isHotReloadMode() || !compiledTemplates.isPresent()) {
+        if (shouldCompileTemplates()) {
             this.compiledTemplates = Optional.fromNullable(compileTemplates());
         }
 
@@ -54,6 +52,10 @@ public class DefaultCompiledTemplatesHolder implements InitializingBean, Compile
         if (preCompileTemplates) {
             this.compiledTemplates = Optional.fromNullable(compileTemplates());
         }
+    }
+
+    private boolean shouldCompileTemplates() {
+        return isHotReloadMode() || !compiledTemplates.isPresent();
     }
 
     private SoyTofu compileTemplates() throws IOException {

--- a/spring-soy-view/src/test/resources/templates/sub/template4.soy
+++ b/spring-soy-view/src/test/resources/templates/sub/template4.soy
@@ -1,0 +1,8 @@
+{namespace soy.example}
+
+/**
+ * Classic insult.
+ */
+{template .insult}
+<p>Your momma is so...</p>
+{/template}

--- a/spring-soy-view/src/test/resources/templates/sub/template5.soy
+++ b/spring-soy-view/src/test/resources/templates/sub/template5.soy
@@ -1,0 +1,8 @@
+{namespace soy.example}
+
+/**
+ * Classic complement.
+ */
+{template .compliment}
+<p>Your momma is so...</p>
+{/template}


### PR DESCRIPTION
Utilize PathMatchingResourcePatternResolver and a String valued templatesLocation to be more agnostic to template location.  If a client has a pressing need to resolve templates that aren't on the standard classpath or cannot be addressed with simple URLs (by DefaultResourceLoader), they can provide their own resource loader.

A client's usage should remain the same.
