### PR TITLE
Fix for IE8 Content Type Request Header

### DIFF
--- a/spring-soy-view/src/main/java/pl/matisoft/soy/DefaultContentNegotiator.java
+++ b/spring-soy-view/src/main/java/pl/matisoft/soy/DefaultContentNegotiator.java
@@ -32,7 +32,7 @@ public class DefaultContentNegotiator implements ContentNegotiator {
 	public static final List<String> DEFAULT_SUPPORTED_CONTENT_TYPES = unmodifiableList(asList("text/html"));
 	public static final String ACCEPT_HEADER = "Accept";
 
-	private static final String CONTENT_TYPE_DELIMITER = ",";
+    private static final String CONTENT_TYPE_DELIMITER = ",\\s*";
 
 	private List<String> supportedContentTypes;
 	private boolean favorParameterOverAcceptHeader;

--- a/spring-soy-view/src/test/java/pl/matisoft/soy/DefaultContentNegotiatorTest.java
+++ b/spring-soy-view/src/test/java/pl/matisoft/soy/DefaultContentNegotiatorTest.java
@@ -21,8 +21,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-import pl.matisoft.soy.DefaultContentNegotiator;
-
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ ServletRequestAttributes.class, HttpServletRequest.class, RequestContextHolder.class })
 public class DefaultContentNegotiatorTest {
@@ -109,4 +107,13 @@ public class DefaultContentNegotiatorTest {
 		assertEquals(asList("text/html", "application/xhtml+xml", "application/xml;q=0.9"),
 				contentNegotiator.contentTypes());
 	}
+
+    @Test
+    public void testContentTypesWhenNeedsSplitWithWhitespace() {
+        when(req.getHeaders(ACCEPT_HEADER)).thenReturn(
+                enumeration(asList("text/html, application/xhtml+xml, application/xml;q=0.9")));
+
+        assertEquals(asList("text/html", "application/xhtml+xml", "application/xml;q=0.9"),
+                contentNegotiator.contentTypes());
+    }
 }


### PR DESCRIPTION
IE8 sends requests where the accepted content types are not separated by commas, but by commas followed by spaces. I adjusted the regular expression used for splitting the content types to account for this. Without this fix, requests for a soy-template driven web page coming from an IE8 fail with a server error (500) when the webapp runs locally.

Change-Id: Ib60c13dfb3bb7009abeef09de237daf5812143f5
